### PR TITLE
[SW][Mobile][Android] Some photo thumbnails are not shown in the correct orientation in image picker

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/engine/impl/PicassoEngine.java
+++ b/matisse/src/main/java/com/zhihu/matisse/engine/impl/PicassoEngine.java
@@ -15,9 +15,17 @@
  */
 package com.zhihu.matisse.engine.impl;
 
+import static androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_180;
+import static androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_270;
+import static androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_90;
+
+import android.content.ContentResolver;
 import android.content.Context;
+import android.database.Cursor;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.Log;
 import android.widget.ImageView;
 
 import com.squareup.picasso.Picasso;
@@ -29,11 +37,16 @@ import com.zhihu.matisse.engine.ImageEngine;
 
 public class PicassoEngine implements ImageEngine {
 
+    private static final String[] CONTENT_ORIENTATION = new String[] {
+            MediaStore.Images.ImageColumns.ORIENTATION
+    };
+
     @Override
     public void loadThumbnail(Context context, int resize, Drawable placeholder, ImageView imageView, Uri uri) {
         Picasso.get().load(uri).placeholder(placeholder)
                 .resize(resize, resize)
                 .centerCrop()
+                .rotate(getRotation(getExifOrientation(context.getContentResolver(), uri)))
                 .into(imageView);
     }
 
@@ -45,7 +58,10 @@ public class PicassoEngine implements ImageEngine {
 
     @Override
     public void loadImage(Context context, int resizeX, int resizeY, ImageView imageView, Uri uri) {
-        Picasso.get().load(uri).resize(resizeX, resizeY).priority(Picasso.Priority.HIGH)
+        Picasso.get()
+                .load(uri)
+                .resize(resizeX, resizeY)
+                .priority(Picasso.Priority.HIGH)
                 .centerInside().into(imageView);
     }
 
@@ -58,4 +74,60 @@ public class PicassoEngine implements ImageEngine {
     public boolean supportAnimatedGif() {
         return false;
     }
+
+    private int getRotation(int rotationId) {
+        int rotationValue = 0;
+        switch (rotationId) {
+            case ORIENTATION_ROTATE_90:
+                rotationValue = 90;
+                break;
+            case ORIENTATION_ROTATE_180:
+                rotationValue = 180;
+                break;
+            case ORIENTATION_ROTATE_270:
+                rotationValue = 270;
+                break;
+        }
+
+        return rotationValue;
+    }
+
+    private int getExifOrientation(ContentResolver contentResolver, Uri uri) {
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(uri, CONTENT_ORIENTATION, null, null, null);
+
+            if (cursor == null || !cursor.moveToFirst()) {
+                return 0;
+            }
+            // CONTENT_ORIENTATION returns the actual angle integer such as 90, 180, etc.
+            // But BitmapHunter requires the ExifInterface's constants.
+            int contentOrientation = cursor.getInt(0);
+            int exifOrientation;
+            switch (contentOrientation) {
+                case 90:
+                    exifOrientation = ORIENTATION_ROTATE_90;
+                    break;
+                case 180:
+                    exifOrientation = ORIENTATION_ROTATE_180;
+                    break;
+                case 270:
+                    exifOrientation = ORIENTATION_ROTATE_270;
+                    break;
+                default:
+                    exifOrientation = 0;
+                    break;
+            }
+            Log.d("PicassoEngine", "exifOrientation: " + exifOrientation);
+            return exifOrientation;
+        } catch (RuntimeException ignored) {
+            // If the orientation column doesn't exist, assume no rotation.
+            return 0;
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
 }

--- a/sample/src/main/java/com/zhihu/matisse/sample/CustomMatisseActivity.java
+++ b/sample/src/main/java/com/zhihu/matisse/sample/CustomMatisseActivity.java
@@ -159,7 +159,6 @@ public class CustomMatisseActivity extends AppCompatActivity implements View.OnC
                 .countable(countable)
                 .maxSelectable(maxSelectable)
                 .enablePreview(false)
-                .imageEngine(new PicassoEngine())
                 .showUseOrigin(false)
 //                .maxSelectablePerMediaType(maxSelectable, maxVideoSeletable)
                 .addFilter(new GifSizeFilter(320, 320, 5 * Filter.K * Filter.K))


### PR DESCRIPTION
### Changes
- Added orientation checking and adjust for loading thumbnail

### Impact
- Should be showing now the correct thumbnail orientation on the imagepicker

[WRIKE](https://www.wrike.com/open.htm?id=630483638)